### PR TITLE
README: clone without a GitHub account

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ easy to fork and contribute any changes back upstream.
 
 1. Check out Renv into `~/.Renv`.
 
-        $ cd
-        $ git clone https://github.com/viking/Renv.git .Renv
+        $ git clone https://github.com/viking/Renv.git ~/.Renv
 
 2. Add `~/.Renv/bin` to your `$PATH` for access to the `Renv`
    command-line utility.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ easy to fork and contribute any changes back upstream.
 1. Check out Renv into `~/.Renv`.
 
         $ cd
-        $ git clone git://github.com/viking/Renv.git .Renv
+        $ git clone https://github.com/viking/Renv.git .Renv
 
 2. Add `~/.Renv/bin` to your `$PATH` for access to the `Renv`
    command-line utility.


### PR DESCRIPTION
Previously, the README instructions would require a GitHub account setup with SSH to clone the repository.  The only advantage I can see of doing things this way is if you had permissions to push updates to vubiostat/Renv.  Using `https:` allows anyone to clone this.

I also removed `cd` in favor of specifying the clone location at the end of the `clone` command: This has the advantage that it's one line instead of two, and it's more transparent (I believe more people are familiar with `~` than the fact that `cd` defaults to taking you to your home directory).